### PR TITLE
Fix workflow build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
           toolchain: stable-2020-10-08
           target: wasm32-unknown-unknown
 
+      - name: Add wasm32
+        run: rustup target add wasm32-unknown-unknown
+
       - name: Check that build works
         run: ./build.sh
         # TODO: check that files in `res` are unchanged

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           toolchain: stable-2020-10-08
           target: wasm32-unknown-unknown
 
-      - name: Add wasm32
+      - name: Add wasm32 target
         run: rustup target add wasm32-unknown-unknown
 
       - name: Check that build works


### PR DESCRIPTION
The CI workflow was failing with this error:

```
    Compiling ahash v0.4.7
error[E0463]: can't find crate for `core`
  |
  = note: the `wasm32-unknown-unknown` target may not be installed
  = help: consider downloading the target with `rustup target add wasm32-unknown-unknown`

error: aborting due to previous error
```

This PR adds a step to install the `wasm32-unknown-unknown` target.
