### PR TITLE
feat: migrate to near-sdk-rs 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
+name = "ahash"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.2",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +126,12 @@ dependencies = [
  "object 0.23.0",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
@@ -222,8 +239,18 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5a26c53ddf60281f18e7a29b20db7ba3db82a9d81b9650bfaa02d646f50d364"
 dependencies = [
- "borsh-derive",
- "hashbrown",
+ "borsh-derive 0.8.1",
+ "hashbrown 0.9.1",
+]
+
+[[package]]
+name = "borsh"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
+dependencies = [
+ "borsh-derive 0.9.3",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -232,8 +259,21 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b637a47728b78a78cd7f4b85bf06d71ef4221840e059a38f048be2422bf673b2"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
+ "borsh-derive-internal 0.8.1",
+ "borsh-schema-derive-internal 0.8.1",
+ "proc-macro-crate",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
+dependencies = [
+ "borsh-derive-internal 0.9.3",
+ "borsh-schema-derive-internal 0.9.3",
  "proc-macro-crate",
  "proc-macro2",
  "syn",
@@ -251,10 +291,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh-derive-internal"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "borsh-schema-derive-internal"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf78ee4a98c8cb9eba1bac3d3e2a1ea3d7673c719ce691e67b5cbafc472d3b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -286,6 +348,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
+name = "bytesize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70"
+
+[[package]]
 name = "c2-chacha"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,7 +374,7 @@ dependencies = [
  "cached_proc_macro",
  "cached_proc_macro_types",
  "futures",
- "hashbrown",
+ "hashbrown 0.9.1",
  "once_cell",
 ]
 
@@ -749,8 +817,8 @@ dependencies = [
 name = "defi"
 version = "0.0.1"
 dependencies = [
- "near-contract-standards",
- "near-sdk",
+ "near-contract-standards 3.2.0",
+ "near-sdk 3.1.0",
 ]
 
 [[package]]
@@ -934,7 +1002,7 @@ dependencies = [
  "fixed-hash",
  "impl-rlp",
  "impl-serde",
- "primitive-types",
+ "primitive-types 0.9.0",
  "uint",
 ]
 
@@ -988,8 +1056,8 @@ checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 name = "fungible-token"
 version = "1.0.0"
 dependencies = [
- "near-contract-standards",
- "near-sdk",
+ "near-contract-standards 4.0.0-pre.7",
+ "near-sdk 4.0.0-pre.7",
 ]
 
 [[package]]
@@ -998,7 +1066,7 @@ version = "0.0.1"
 dependencies = [
  "defi",
  "fungible-token",
- "near-sdk",
+ "near-sdk 3.1.0",
  "near-sdk-sim",
 ]
 
@@ -1187,7 +1255,16 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
- "ahash",
+ "ahash 0.4.7",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.4",
 ]
 
 [[package]]
@@ -1283,7 +1360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.9.1",
  "serde",
 ]
 
@@ -1513,12 +1590,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 
 [[package]]
+name = "near-account-id"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd61f43cedc1bb7a7c097ef3adbab0092a51185dca0e48d5851b37818e13978"
+dependencies = [
+ "borsh 0.9.3",
+ "serde",
+]
+
+[[package]]
 name = "near-contract-standards"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7421d0a5c7aeb57b37a0cf3a71a7aefbbdc7727f9811d9dd86fa55e4f0de4d3"
 dependencies = [
- "near-sdk",
+ "near-sdk 3.1.0",
+]
+
+[[package]]
+name = "near-contract-standards"
+version = "4.0.0-pre.7"
+source = "git+https://github.com/near/near-sdk-rs?rev=1c5106bf0b3380d66d2689174f5e50b612101331#1c5106bf0b3380d66d2689174f5e50b612101331"
+dependencies = [
+ "near-sdk 4.0.0-pre.7",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1529,7 +1626,7 @@ checksum = "bb14bec070cfd808438712cda5d54703001b9cf1196c8afaeadc9514e06d00a3"
 dependencies = [
  "arrayref",
  "blake2",
- "borsh",
+ "borsh 0.8.1",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -1538,6 +1635,33 @@ dependencies = [
  "lazy_static",
  "libc",
  "parity-secp256k1",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "serde",
+ "serde_json",
+ "subtle",
+ "thiserror",
+]
+
+[[package]]
+name = "near-crypto"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f68d8d55bd2a457eba5956d8c1255e288c47f394ca6fffe6184d19664bf0bc4c"
+dependencies = [
+ "arrayref",
+ "blake2",
+ "borsh 0.9.3",
+ "bs58",
+ "c2-chacha",
+ "curve25519-dalek",
+ "derive_more",
+ "ed25519-dalek",
+ "lazy_static",
+ "libc",
+ "near-account-id",
+ "parity-secp256k1",
+ "primitive-types 0.10.0",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "serde",
@@ -1563,9 +1687,9 @@ version = "0.1.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde79472f7cfc0675733b65f79f9e50c20bfbb9806298ab2872916869a45dccd"
 dependencies = [
- "borsh",
- "near-crypto",
- "near-primitives",
+ "borsh 0.8.1",
+ "near-crypto 0.1.0",
+ "near-primitives 0.1.0-pre.1",
  "rand 0.7.3",
 ]
 
@@ -1575,8 +1699,8 @@ version = "0.1.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75ed2263518ca67a3c158c144813832fd96f48ab239494bb9d7793d315f31417"
 dependencies = [
- "base64",
- "borsh",
+ "base64 0.13.0",
+ "borsh 0.8.1",
  "bs58",
  "byteorder",
  "chrono",
@@ -1585,12 +1709,43 @@ dependencies = [
  "hex",
  "jemallocator",
  "lazy_static",
- "near-crypto",
- "near-primitives-core",
- "near-rpc-error-macro",
- "near-vm-errors",
+ "near-crypto 0.1.0",
+ "near-primitives-core 0.4.0",
+ "near-rpc-error-macro 0.1.0",
+ "near-vm-errors 4.0.0-pre.1",
  "num-rational",
- "primitive-types",
+ "primitive-types 0.9.0",
+ "rand 0.7.3",
+ "reed-solomon-erasure",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smart-default",
+ "validator",
+]
+
+[[package]]
+name = "near-primitives"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d93aaf84ad4f5ccf780d8a0029c6fb636a2e6c1ddb3c772dee4686529e30a8"
+dependencies = [
+ "base64 0.13.0",
+ "borsh 0.9.3",
+ "bs58",
+ "byteorder",
+ "bytesize",
+ "chrono",
+ "derive_more",
+ "easy-ext",
+ "hex",
+ "near-crypto 0.10.0",
+ "near-primitives-core 0.10.0",
+ "near-rpc-error-macro 0.10.0",
+ "near-vm-errors 0.10.0",
+ "num-rational",
+ "primitive-types 0.10.0",
  "rand 0.7.3",
  "reed-solomon-erasure",
  "regex",
@@ -1607,12 +1762,31 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2b3fb5acf3a494aed4e848446ef2d6ebb47dbe91c681105d4d1786c2ee63e52"
 dependencies = [
- "base64",
- "borsh",
+ "base64 0.13.0",
+ "borsh 0.8.1",
  "bs58",
  "derive_more",
  "hex",
  "lazy_static",
+ "num-rational",
+ "serde",
+ "serde_json",
+ "sha2",
+]
+
+[[package]]
+name = "near-primitives-core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d88b2b0f418c1174214fb51106c90251f61ecfe4c7063f149c2e199ec2850fd"
+dependencies = [
+ "base64 0.11.0",
+ "borsh 0.9.3",
+ "bs58",
+ "derive_more",
+ "hex",
+ "lazy_static",
+ "near-account-id",
  "num-rational",
  "serde",
  "serde_json",
@@ -1633,12 +1807,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-rpc-error-core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a98c9bd7edee4dcfc293e3511e9fab826bcd6fbfbfe06124a1164b94ee60351"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+]
+
+[[package]]
 name = "near-rpc-error-macro"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6111d713e90c7c551dee937f4a06cb9ea2672243455a4454cc7566387ba2d9"
 dependencies = [
- "near-rpc-error-core",
+ "near-rpc-error-core 0.1.0",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "near-rpc-error-macro"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abade92d0fc76a6c25aeb82f3e7fd97678ab5d0fd92b80149a65d1088e86505"
+dependencies = [
+ "near-rpc-error-core 0.10.0",
  "proc-macro2",
  "quote",
  "serde",
@@ -1652,19 +1852,19 @@ version = "4.0.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e4c0a4cd2ee5ccbc1fd5d492180ebf33ac1159d721b2e0c58c11953131fb449"
 dependencies = [
- "borsh",
+ "borsh 0.8.1",
  "byteorder",
  "ethereum-types",
  "hex",
  "lazy_static",
  "log",
- "near-crypto",
+ "near-crypto 0.1.0",
  "near-metrics",
- "near-primitives",
+ "near-primitives 0.1.0-pre.1",
  "near-runtime-utils",
  "near-store",
- "near-vm-errors",
- "near-vm-logic",
+ "near-vm-errors 4.0.0-pre.1",
+ "near-vm-logic 4.0.0-pre.1",
  "near-vm-runner",
  "num-bigint",
  "num-rational",
@@ -1690,12 +1890,29 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7383e242d3e07bf0951e8589d6eebd7f18bb1c1fc5fbec3fad796041a6aebd1"
 dependencies = [
- "base64",
- "borsh",
+ "base64 0.13.0",
+ "borsh 0.8.1",
  "bs58",
- "near-primitives-core",
- "near-sdk-macros",
- "near-vm-logic",
+ "near-primitives-core 0.4.0",
+ "near-sdk-macros 3.1.0",
+ "near-vm-logic 4.0.0-pre.1",
+ "serde",
+ "serde_json",
+ "wee_alloc",
+]
+
+[[package]]
+name = "near-sdk"
+version = "4.0.0-pre.7"
+source = "git+https://github.com/near/near-sdk-rs?rev=1c5106bf0b3380d66d2689174f5e50b612101331#1c5106bf0b3380d66d2689174f5e50b612101331"
+dependencies = [
+ "base64 0.13.0",
+ "borsh 0.9.3",
+ "bs58",
+ "near-primitives-core 0.10.0",
+ "near-sdk-macros 4.0.0-pre.7",
+ "near-sys",
+ "near-vm-logic 0.10.0",
  "serde",
  "serde_json",
  "wee_alloc",
@@ -1726,6 +1943,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-sdk-macros"
+version = "4.0.0-pre.7"
+source = "git+https://github.com/near/near-sdk-rs?rev=1c5106bf0b3380d66d2689174f5e50b612101331#1c5106bf0b3380d66d2689174f5e50b612101331"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "near-sdk-sim"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,13 +1961,13 @@ checksum = "6f9be539455733f5cff63febaee07dcdc48c0a9940856257a1989e84a5552d7a"
 dependencies = [
  "funty",
  "lazy-static-include",
- "near-crypto",
+ "near-crypto 0.1.0",
  "near-pool",
- "near-primitives",
+ "near-primitives 0.1.0-pre.1",
  "near-runtime",
- "near-sdk",
+ "near-sdk 3.1.0",
  "near-store",
- "near-vm-logic",
+ "near-vm-logic 4.0.0-pre.1",
 ]
 
 [[package]]
@@ -1748,14 +1976,14 @@ version = "0.1.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e880d1d9a4ca5a1ca1ea0366fd80e295465f90cd0c1209f45d6d0b7a443ed4"
 dependencies = [
- "borsh",
+ "borsh 0.8.1",
  "byteorder",
  "cached",
  "derive_more",
  "elastic-array",
  "lazy_static",
- "near-crypto",
- "near-primitives",
+ "near-crypto 0.1.0",
+ "near-primitives 0.1.0-pre.1",
  "num_cpus",
  "rand 0.7.3",
  "rocksdb",
@@ -1765,15 +1993,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-sys"
+version = "0.1.0"
+source = "git+https://github.com/near/near-sdk-rs?rev=1c5106bf0b3380d66d2689174f5e50b612101331#1c5106bf0b3380d66d2689174f5e50b612101331"
+
+[[package]]
+name = "near-vm-errors"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e781248bed1f8e4792aee0c0362cf8bc831fc9f51573bc43807b5e07e0e7db81"
+dependencies = [
+ "borsh 0.9.3",
+ "hex",
+ "near-account-id",
+ "near-rpc-error-macro 0.10.0",
+ "serde",
+]
+
+[[package]]
 name = "near-vm-errors"
 version = "4.0.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e281d8730ed8cb0e3e69fb689acee6b93cdb43824cd69a8ffd7e1bfcbd1177d7"
 dependencies = [
- "borsh",
+ "borsh 0.8.1",
  "hex",
- "near-rpc-error-macro",
+ "near-rpc-error-macro 0.1.0",
  "serde",
+]
+
+[[package]]
+name = "near-vm-logic"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c06b3cb3ccf0423a9ba6908ccf07abe19c3c34319af200c733f34b7ac5af0ab"
+dependencies = [
+ "base64 0.13.0",
+ "borsh 0.9.3",
+ "bs58",
+ "byteorder",
+ "near-account-id",
+ "near-crypto 0.10.0",
+ "near-primitives 0.10.0",
+ "near-primitives-core 0.10.0",
+ "near-vm-errors 0.10.0",
+ "ripemd160",
+ "serde",
+ "sha2",
+ "sha3",
 ]
 
 [[package]]
@@ -1782,13 +2049,13 @@ version = "4.0.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e11cb28a2d07f37680efdaf860f4c9802828c44fc50c08009e7884de75d982c5"
 dependencies = [
- "base64",
- "borsh",
+ "base64 0.13.0",
+ "borsh 0.8.1",
  "bs58",
  "byteorder",
- "near-primitives-core",
+ "near-primitives-core 0.4.0",
  "near-runtime-utils",
- "near-vm-errors",
+ "near-vm-errors 4.0.0-pre.1",
  "serde",
  "sha2",
  "sha3",
@@ -1801,12 +2068,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93a66e94e12ec66a29674cc4efa975c280415aa0c944d7294cedbdb0c3858b48"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.8.1",
  "cached",
  "log",
- "near-primitives",
- "near-vm-errors",
- "near-vm-logic",
+ "near-primitives 0.1.0-pre.1",
+ "near-vm-errors 4.0.0-pre.1",
+ "near-vm-logic 4.0.0-pre.1",
  "parity-wasm",
  "pwasm-utils",
  "tracing",
@@ -2062,6 +2329,17 @@ dependencies = [
  "impl-codec",
  "impl-rlp",
  "impl-serde",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e90f6931e6b3051e208a449c342246cb7c786ef300789b95619f46f1dd75d9b0"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
  "uint",
 ]
 
@@ -2372,6 +2650,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "ripemd160"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+dependencies = [
+ "block-buffer",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,8 @@ dependencies = [
 [[package]]
 name = "near-contract-standards"
 version = "4.0.0-pre.7"
-source = "git+https://github.com/near/near-sdk-rs?rev=1c5106bf0b3380d66d2689174f5e50b612101331#1c5106bf0b3380d66d2689174f5e50b612101331"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c4f636adbffbd9399610cb6445894c64c6c8fcf9ea4e607021f252a1e0459f"
 dependencies = [
  "near-sdk 4.0.0-pre.7",
  "serde",
@@ -1904,7 +1905,8 @@ dependencies = [
 [[package]]
 name = "near-sdk"
 version = "4.0.0-pre.7"
-source = "git+https://github.com/near/near-sdk-rs?rev=1c5106bf0b3380d66d2689174f5e50b612101331#1c5106bf0b3380d66d2689174f5e50b612101331"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f17c763e91999827a2ad30b909f79e82a56c448bf7170ed72841756397e5a3"
 dependencies = [
  "base64 0.13.0",
  "borsh 0.9.3",
@@ -1945,7 +1947,8 @@ dependencies = [
 [[package]]
 name = "near-sdk-macros"
 version = "4.0.0-pre.7"
-source = "git+https://github.com/near/near-sdk-rs?rev=1c5106bf0b3380d66d2689174f5e50b612101331#1c5106bf0b3380d66d2689174f5e50b612101331"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07b8d59302bf900707c41654a7ba178c5a2d8040a8812647f6b7e7e28dc5b1"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -1995,7 +1998,8 @@ dependencies = [
 [[package]]
 name = "near-sys"
 version = "0.1.0"
-source = "git+https://github.com/near/near-sdk-rs?rev=1c5106bf0b3380d66d2689174f5e50b612101331#1c5106bf0b3380d66d2689174f5e50b612101331"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6a7aa3f46fac44416d8a93d14f30a562c4d730a1c6bf14bffafab5f475c244a"
 
 [[package]]
 name = "near-vm-errors"

--- a/ft/Cargo.toml
+++ b/ft/Cargo.toml
@@ -8,6 +8,5 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-near-sdk = { git = "https://github.com/near/near-sdk-rs", rev = "1c5106bf0b3380d66d2689174f5e50b612101331" }
-near-contract-standards = { git = "https://github.com/near/near-sdk-rs", rev = "1c5106bf0b3380d66d2689174f5e50b612101331" }
-
+near-sdk = "4.0.0-pre.7"
+near-contract-standards = "4.0.0-pre.7"

--- a/ft/Cargo.toml
+++ b/ft/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-near-sdk = "3.1.0"
-near-contract-standards = "3.1.1"
+near-sdk = { git = "https://github.com/near/near-sdk-rs", rev = "1c5106bf0b3380d66d2689174f5e50b612101331" }
+near-contract-standards = { git = "https://github.com/near/near-sdk-rs", rev = "1c5106bf0b3380d66d2689174f5e50b612101331" }
+

--- a/ft/src/lib.rs
+++ b/ft/src/lib.rs
@@ -21,10 +21,8 @@ use near_contract_standards::fungible_token::metadata::{
 use near_contract_standards::fungible_token::FungibleToken;
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::LazyOption;
-use near_sdk::json_types::{ValidAccountId, U128};
+use near_sdk::json_types::U128;
 use near_sdk::{env, log, near_bindgen, AccountId, Balance, PanicOnDefault, PromiseOrValue};
-
-near_sdk::setup_alloc!();
 
 #[near_bindgen]
 #[derive(BorshDeserialize, BorshSerialize, PanicOnDefault)]
@@ -40,7 +38,7 @@ impl Contract {
     /// Initializes the contract with the given total supply owned by the given `owner_id` with
     /// default metadata (for example purposes only).
     #[init]
-    pub fn new_default_meta(owner_id: ValidAccountId, total_supply: U128) -> Self {
+    pub fn new_default_meta(owner_id: AccountId, total_supply: U128) -> Self {
         Self::new(
             owner_id,
             total_supply,
@@ -60,7 +58,7 @@ impl Contract {
     /// the given fungible token metadata.
     #[init]
     pub fn new(
-        owner_id: ValidAccountId,
+        owner_id: AccountId,
         total_supply: U128,
         metadata: FungibleTokenMetadata,
     ) -> Self {
@@ -70,8 +68,14 @@ impl Contract {
             token: FungibleToken::new(b"a".to_vec()),
             metadata: LazyOption::new(b"m".to_vec(), Some(&metadata)),
         };
-        this.token.internal_register_account(owner_id.as_ref());
-        this.token.internal_deposit(owner_id.as_ref(), total_supply.into());
+        this.token.internal_register_account(&owner_id);
+        this.token.internal_deposit(&owner_id, total_supply.into());
+        near_contract_standards::fungible_token::events::FtMint {
+            owner_id: &owner_id,
+            amount: &total_supply,
+            memo: Some("Initial tokens supply is minted"),
+        }
+        .emit();
         this
     }
 
@@ -104,7 +108,7 @@ mod tests {
 
     const TOTAL_SUPPLY: Balance = 1_000_000_000_000_000;
 
-    fn get_context(predecessor_account_id: ValidAccountId) -> VMContextBuilder {
+    fn get_context(predecessor_account_id: AccountId) -> VMContextBuilder {
         let mut builder = VMContextBuilder::new();
         builder
             .current_account_id(accounts(0))


### PR DESCRIPTION
This picks up FT Events support: https://github.com/near/near-sdk-rs/pull/723

~I think we should not merge this PR before there is at least a pre release of near-sdk-rs~ (near-sdk-rs 4.0.0-pre.7 has the necessary support now)

With this change Indexer for Explorer picked up the initial minting event just fine:

<img width="650" alt="image" src="https://user-images.githubusercontent.com/304265/153725591-e13f13bc-0975-4b11-b508-5b80dd1c500c.png">

https://explorer.testnet.near.org/transactions/DnfXatQjvVK8ER6oGBVT5tGdKEd8k1oH276HweXWNvY6

cc @austinabell 