### PR TITLE
Fixed simulation testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,8 +817,8 @@ dependencies = [
 name = "defi"
 version = "0.0.1"
 dependencies = [
- "near-contract-standards 3.2.0",
- "near-sdk 3.1.0",
+ "near-contract-standards",
+ "near-sdk",
 ]
 
 [[package]]
@@ -1056,8 +1056,8 @@ checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 name = "fungible-token"
 version = "1.0.0"
 dependencies = [
- "near-contract-standards 4.0.0-pre.7",
- "near-sdk 4.0.0-pre.7",
+ "near-contract-standards",
+ "near-sdk",
 ]
 
 [[package]]
@@ -1066,7 +1066,7 @@ version = "0.0.1"
 dependencies = [
  "defi",
  "fungible-token",
- "near-sdk 3.1.0",
+ "near-sdk",
  "near-sdk-sim",
 ]
 
@@ -1601,20 +1601,11 @@ dependencies = [
 
 [[package]]
 name = "near-contract-standards"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7421d0a5c7aeb57b37a0cf3a71a7aefbbdc7727f9811d9dd86fa55e4f0de4d3"
-dependencies = [
- "near-sdk 3.1.0",
-]
-
-[[package]]
-name = "near-contract-standards"
 version = "4.0.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c4f636adbffbd9399610cb6445894c64c6c8fcf9ea4e607021f252a1e0459f"
 dependencies = [
- "near-sdk 4.0.0-pre.7",
+ "near-sdk",
  "serde",
  "serde_json",
 ]
@@ -1887,23 +1878,6 @@ dependencies = [
 
 [[package]]
 name = "near-sdk"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7383e242d3e07bf0951e8589d6eebd7f18bb1c1fc5fbec3fad796041a6aebd1"
-dependencies = [
- "base64 0.13.0",
- "borsh 0.8.1",
- "bs58",
- "near-primitives-core 0.4.0",
- "near-sdk-macros 3.1.0",
- "near-vm-logic 4.0.0-pre.1",
- "serde",
- "serde_json",
- "wee_alloc",
-]
-
-[[package]]
-name = "near-sdk"
 version = "4.0.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4f17c763e91999827a2ad30b909f79e82a56c448bf7170ed72841756397e5a3"
@@ -1912,36 +1886,12 @@ dependencies = [
  "borsh 0.9.3",
  "bs58",
  "near-primitives-core 0.10.0",
- "near-sdk-macros 4.0.0-pre.7",
+ "near-sdk-macros",
  "near-sys",
  "near-vm-logic 0.10.0",
  "serde",
  "serde_json",
  "wee_alloc",
-]
-
-[[package]]
-name = "near-sdk-core"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284a78d9eb8eda58330462fa0023a6d7014c941df1f0387095e7dfd1dc0f2bce"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "near-sdk-macros"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2037337438f97d1ce5f7c896cf229dc56dacd5c01142d1ef95a7d778cde6ce7d"
-dependencies = [
- "near-sdk-core",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1958,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-sim"
-version = "3.2.0"
+version = "4.0.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9be539455733f5cff63febaee07dcdc48c0a9940856257a1989e84a5552d7a"
+checksum = "3bedc5bfe554835bee8e0f00801e644add7fa81b8de8867b6be1d3fb41864390"
 dependencies = [
  "funty",
  "lazy-static-include",
@@ -1968,7 +1918,7 @@ dependencies = [
  "near-pool",
  "near-primitives 0.1.0-pre.1",
  "near-runtime",
- "near-sdk 3.1.0",
+ "near-sdk",
  "near-store",
  "near-vm-logic 4.0.0-pre.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Near Inc <hello@near.org>"]
 edition = "2018"
 
 [dev-dependencies]
-near-sdk = "3.1.0"
-near-sdk-sim = "3.1.1"
+near-sdk = "4.0.0-pre.6"
+near-sdk-sim = "4.0.0-pre.6"
 
 # remember to include a line for each contract
 fungible-token = { path = "./ft" }

--- a/test-contract-defi/Cargo.toml
+++ b/test-contract-defi/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-near-sdk = "3.1.0"
-near-contract-standards = "3.1.1"
+near-sdk = "4.0.0-pre.7"
+near-contract-standards = "4.0.0-pre.7"
 

--- a/test-contract-defi/src/lib.rs
+++ b/test-contract-defi/src/lib.rs
@@ -3,17 +3,15 @@ Some hypothetical DeFi contract that will do smart things with the transferred t
 */
 use near_contract_standards::fungible_token::receiver::FungibleTokenReceiver;
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::json_types::{ValidAccountId, U128};
+use near_sdk::json_types::{U128};
 use near_sdk::{
-    env, ext_contract, log, near_bindgen, setup_alloc, AccountId, Balance, Gas, PanicOnDefault,
+    env, ext_contract, log, near_bindgen, AccountId, Balance, Gas, PanicOnDefault,
     PromiseOrValue,
 };
 
-setup_alloc!();
-
-const BASE_GAS: Gas = 5_000_000_000_000;
-const PROMISE_CALL: Gas = 5_000_000_000_000;
-const GAS_FOR_FT_ON_TRANSFER: Gas = BASE_GAS + PROMISE_CALL;
+const BASE_GAS: u64 = 5_000_000_000_000;
+const PROMISE_CALL: u64 = 5_000_000_000_000;
+const GAS_FOR_FT_ON_TRANSFER: u64 = BASE_GAS + PROMISE_CALL;
 
 const NO_DEPOSIT: Balance = 0;
 
@@ -37,7 +35,7 @@ trait ValueReturnTrait {
 #[near_bindgen]
 impl DeFi {
     #[init]
-    pub fn new(fungible_token_account_id: ValidAccountId) -> Self {
+    pub fn new(fungible_token_account_id: AccountId) -> Self {
         assert!(!env::state_exists(), "Already initialized");
         Self { fungible_token_account_id: fungible_token_account_id.into() }
     }
@@ -50,7 +48,7 @@ impl FungibleTokenReceiver for DeFi {
     /// value_please will attempt to parse `msg` as an integer and return a U128 version of it
     fn ft_on_transfer(
         &mut self,
-        sender_id: ValidAccountId,
+        sender_id: AccountId,
         amount: U128,
         msg: String,
     ) -> PromiseOrValue<U128> {
@@ -68,9 +66,9 @@ impl FungibleTokenReceiver for DeFi {
                 let account_id = env::current_account_id();
                 ext_self::value_please(
                     msg,
-                    &account_id,
+                    account_id,
                     NO_DEPOSIT,
-                    prepaid_gas - GAS_FOR_FT_ON_TRANSFER,
+                    prepaid_gas - Gas::from(GAS_FOR_FT_ON_TRANSFER),
                 )
                 .into()
             }

--- a/tests/sim/no_macros.rs
+++ b/tests/sim/no_macros.rs
@@ -25,7 +25,7 @@ fn simulate_simple_transfer() {
         ft.account_id(),
         "ft_transfer",
         &json!({
-            "receiver_id": alice.valid_account_id(),
+            "receiver_id": alice.account_id(),
             "amount": U128::from(transfer_amount)
         })
         .to_string()
@@ -40,7 +40,7 @@ fn simulate_simple_transfer() {
             ft.account_id(),
             "ft_balance_of",
             &json!({
-                "account_id": root.valid_account_id()
+                "account_id": root.account_id()
             })
             .to_string()
             .into_bytes(),
@@ -51,7 +51,7 @@ fn simulate_simple_transfer() {
             ft.account_id(),
             "ft_balance_of",
             &json!({
-                "account_id": alice.valid_account_id()
+                "account_id": alice.account_id()
             })
             .to_string()
             .into_bytes(),

--- a/tests/sim/utils.rs
+++ b/tests/sim/utils.rs
@@ -19,10 +19,10 @@ const DEFI_ID: &str = "defi";
 // Register the given `user` with FT contract
 pub fn register_user(user: &near_sdk_sim::UserAccount) {
     user.call(
-        FT_ID.to_string(),
+        FT_ID.parse().unwrap(),
         "storage_deposit",
         &json!({
-            "account_id": user.valid_account_id()
+            "account_id": user.account_id()
         })
         .to_string()
         .into_bytes(),
@@ -35,13 +35,13 @@ pub fn register_user(user: &near_sdk_sim::UserAccount) {
 pub fn init_no_macros(initial_balance: u128) -> (UserAccount, UserAccount, UserAccount) {
     let root = init_simulator(None);
 
-    let ft = root.deploy(&FT_WASM_BYTES, FT_ID.into(), STORAGE_AMOUNT);
+    let ft = root.deploy(&FT_WASM_BYTES, FT_ID.parse().unwrap(), STORAGE_AMOUNT);
 
     ft.call(
-        FT_ID.into(),
+        FT_ID.parse().unwrap(),
         "new_default_meta",
         &json!({
-            "owner_id": root.valid_account_id(),
+            "owner_id": root.account_id(),
             "total_supply": U128::from(initial_balance),
         })
         .to_string()
@@ -51,7 +51,7 @@ pub fn init_no_macros(initial_balance: u128) -> (UserAccount, UserAccount, UserA
     )
     .assert_success();
 
-    let alice = root.create_user("alice".to_string(), to_yocto("100"));
+    let alice = root.create_user("alice".parse().unwrap(), to_yocto("100"));
     register_user(&alice);
 
     (root, ft, alice)
@@ -73,11 +73,11 @@ pub fn init_with_macros(
         signer_account: root,
         // init method
         init_method: new_default_meta(
-            root.valid_account_id(),
+            root.account_id(),
             initial_balance.into()
         )
     );
-    let alice = root.create_user("alice".to_string(), to_yocto("100"));
+    let alice = root.create_user("alice".parse().unwrap(), to_yocto("100"));
     register_user(&alice);
 
     let defi = deploy!(
@@ -86,7 +86,7 @@ pub fn init_with_macros(
         bytes: &DEFI_WASM_BYTES,
         signer_account: root,
         init_method: new(
-            ft.valid_account_id()
+            ft.account_id()
         )
     );
 

--- a/tests/sim/with_macros.rs
+++ b/tests/sim/with_macros.rs
@@ -24,13 +24,13 @@ fn simulate_simple_transfer() {
     // Uses default gas amount, `near_sdk_sim::DEFAULT_GAS`
     call!(
         root,
-        ft.ft_transfer(alice.valid_account_id(), transfer_amount.into(), None),
+        ft.ft_transfer(alice.account_id(), transfer_amount.into(), None),
         deposit = 1
     )
     .assert_success();
 
-    let root_balance: U128 = view!(ft.ft_balance_of(root.valid_account_id())).unwrap_json();
-    let alice_balance: U128 = view!(ft.ft_balance_of(alice.valid_account_id())).unwrap_json();
+    let root_balance: U128 = view!(ft.ft_balance_of(root.account_id())).unwrap_json();
+    let alice_balance: U128 = view!(ft.ft_balance_of(alice.account_id())).unwrap_json();
     assert_eq!(initial_balance - transfer_amount, root_balance.0);
     assert_eq!(transfer_amount, alice_balance.0);
 }
@@ -70,7 +70,7 @@ fn simulate_close_account_force_non_empty_balance() {
     let outcome = call!(root, ft.storage_unregister(Some(true)), deposit = 1);
     assert_eq!(
         outcome.logs()[0],
-        format!("Closed @{} with {}", root.valid_account_id(), initial_balance)
+        format!("Closed @{} with {}", root.account_id(), initial_balance)
     );
     outcome.assert_success();
     let result: bool = outcome.unwrap_json();
@@ -96,7 +96,7 @@ fn simulate_transfer_call_with_burned_amount() {
         .function_call(
             "ft_transfer_call".to_string(),
             json!({
-                "receiver_id": defi.valid_account_id(),
+                "receiver_id": defi.account_id(),
                 "amount": transfer_amount.to_string(),
                 "msg": "10",
             })
@@ -119,7 +119,7 @@ fn simulate_transfer_call_with_burned_amount() {
 
     assert_eq!(
         outcome.logs()[1],
-        format!("Closed @{} with {}", root.valid_account_id(), initial_balance - transfer_amount)
+        format!("Closed @{} with {}", root.account_id(), initial_balance - transfer_amount)
     );
 
     let result: bool = outcome.unwrap_json();
@@ -130,7 +130,7 @@ fn simulate_transfer_call_with_burned_amount() {
     assert_eq!(callback_outcome.logs()[0], "The account of the sender was deleted");
     assert_eq!(
         callback_outcome.logs()[1],
-        format!("Account @{} burned {}", root.valid_account_id(), 10)
+        format!("Account @{} burned {}", root.account_id(), 10)
     );
 
     let used_amount: U128 = callback_outcome.unwrap_json();
@@ -142,7 +142,7 @@ fn simulate_transfer_call_with_burned_amount() {
 
     assert_eq!(total_supply.0, transfer_amount - 10);
 
-    let defi_balance: U128 = view!(ft.ft_balance_of(defi.valid_account_id())).unwrap_json();
+    let defi_balance: U128 = view!(ft.ft_balance_of(defi.account_id())).unwrap_json();
     assert_eq!(defi_balance.0, transfer_amount - 10);
 }
 
@@ -159,7 +159,7 @@ fn simulate_transfer_call_with_immediate_return_and_no_refund() {
     call!(
         root,
         ft.ft_transfer_call(
-            defi.valid_account_id(),
+            defi.account_id(),
             transfer_amount.into(),
             None,
             "take-my-money".into()
@@ -168,8 +168,8 @@ fn simulate_transfer_call_with_immediate_return_and_no_refund() {
     )
     .assert_success();
 
-    let root_balance: U128 = view!(ft.ft_balance_of(root.valid_account_id())).unwrap_json();
-    let defi_balance: U128 = view!(ft.ft_balance_of(defi.valid_account_id())).unwrap_json();
+    let root_balance: U128 = view!(ft.ft_balance_of(root.account_id())).unwrap_json();
+    let defi_balance: U128 = view!(ft.ft_balance_of(defi.account_id())).unwrap_json();
     assert_eq!(initial_balance - transfer_amount, root_balance.0);
     assert_eq!(transfer_amount, defi_balance.0);
 }
@@ -184,7 +184,7 @@ fn simulate_transfer_call_when_called_contract_not_registered_with_ft() {
     call!(
         root,
         ft.ft_transfer_call(
-            defi.valid_account_id(),
+            defi.account_id(),
             transfer_amount.into(),
             None,
             "take-my-money".into()
@@ -193,8 +193,8 @@ fn simulate_transfer_call_when_called_contract_not_registered_with_ft() {
     );
 
     // balances remain unchanged
-    let root_balance: U128 = view!(ft.ft_balance_of(root.valid_account_id())).unwrap_json();
-    let defi_balance: U128 = view!(ft.ft_balance_of(defi.valid_account_id())).unwrap_json();
+    let root_balance: U128 = view!(ft.ft_balance_of(root.account_id())).unwrap_json();
+    let defi_balance: U128 = view!(ft.ft_balance_of(defi.account_id())).unwrap_json();
     assert_eq!(initial_balance, root_balance.0);
     assert_eq!(0, defi_balance.0);
 }
@@ -211,7 +211,7 @@ fn simulate_transfer_call_with_promise_and_refund() {
     call!(
         root,
         ft.ft_transfer_call(
-            defi.valid_account_id(),
+            defi.account_id(),
             transfer_amount.into(),
             None,
             refund_amount.to_string()
@@ -219,8 +219,8 @@ fn simulate_transfer_call_with_promise_and_refund() {
         deposit = 1
     );
 
-    let root_balance: U128 = view!(ft.ft_balance_of(root.valid_account_id())).unwrap_json();
-    let defi_balance: U128 = view!(ft.ft_balance_of(defi.valid_account_id())).unwrap_json();
+    let root_balance: U128 = view!(ft.ft_balance_of(root.account_id())).unwrap_json();
+    let defi_balance: U128 = view!(ft.ft_balance_of(defi.account_id())).unwrap_json();
     assert_eq!(initial_balance - transfer_amount + refund_amount, root_balance.0);
     assert_eq!(transfer_amount - refund_amount, defi_balance.0);
 }
@@ -238,7 +238,7 @@ fn simulate_transfer_call_promise_panics_for_a_full_refund() {
     let res = call!(
         root,
         ft.ft_transfer_call(
-            defi.valid_account_id(),
+            defi.account_id(),
             transfer_amount.into(),
             None,
             "no parsey as integer big panic oh no".to_string()
@@ -257,8 +257,8 @@ fn simulate_transfer_call_promise_panics_for_a_full_refund() {
         unreachable!();
     }
 
-    let root_balance: U128 = view!(ft.ft_balance_of(root.valid_account_id())).unwrap_json();
-    let defi_balance: U128 = view!(ft.ft_balance_of(defi.valid_account_id())).unwrap_json();
+    let root_balance: U128 = view!(ft.ft_balance_of(root.account_id())).unwrap_json();
+    let defi_balance: U128 = view!(ft.ft_balance_of(defi.account_id())).unwrap_json();
     assert_eq!(initial_balance, root_balance.0);
     assert_eq!(0, defi_balance.0);
 }


### PR DESCRIPTION
Recently there was a change in how AccountId and ValidAccountId work in the near-sdk. Such change broke the simulation testing in this repository. This commit fixes the problem by:

1. Updating the references in the Cargo.toml files
2. Removing calls to the (now) non-existing method valid_account_id()
3. Updating type references when needed

This PR addresses the issue #108 