### PR TITLE
Fix broken build.sh in Near FT

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,4 +5,4 @@ cd "`dirname $0`"
 cd ft
 cargo build --all --target wasm32-unknown-unknown --release
 cd ..
-cp target/wasm32-unknown-unknown/release/*.wasm ./res/
+cp ft/target/wasm32-unknown-unknown/release/*.wasm ./res/


### PR DESCRIPTION
This file was changed recently and now it fails on copying, thus not updating the .wasm.